### PR TITLE
Post_Table_Migrate

### DIFF
--- a/2020_08_14_195927_create_post_table.php
+++ b/2020_08_14_195927_create_post_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('post', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('body'); 
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('post');
+    }
+}


### PR DESCRIPTION
En este sección se explica y enseña a como crear migraciones con el comando **php artisan make:migration create_post_table** y con una bandera que indica que se llame post
 **--create="post"** y con el comando **php artisan migrate:rollback** devuelve la acción ejecuta y con el comando **php artisan migrate** muestra las tablas creadas.